### PR TITLE
Move git commit to post-run

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,6 +3,7 @@
     name: propose-network-collections-migration-base
     parent: propose-github-updates
     run: tests/playbooks/run.yaml
+    post-run: tests/playbooks/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
       - name: github.com/ansible-community/collection_migration

--- a/tests/playbooks/post.yaml
+++ b/tests/playbooks/post.yaml
@@ -1,0 +1,15 @@
+- hosts: all
+  tasks:
+    - name: Setup collection repo name
+      set_fact:
+        _collection_repo: "github.com/ansible-network/ansible_collections.{{ ansible_collection_namespace }}.{{ ansible_collection_name }}"
+
+    - name: Prepare to commit files
+      args:
+        chdir: "{{ zuul.projects[_collection_repo].src_dir }}"
+      shell: git add --all
+
+    - name: Create git commit
+      args:
+        chdir: "{{ zuul.projects[_collection_repo].src_dir }}"
+      shell: "git commit -s -m 'Updated from network content collector'"

--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -91,13 +91,3 @@
         tox_envlist: black
         tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects[_collection_repo].src_dir }}"
-
-    - name: Prepare to commit files
-      args:
-        chdir: "{{ zuul.projects[_collection_repo].src_dir }}"
-      shell: git add --all
-
-    - name: Create git commit
-      args:
-        chdir: "{{ zuul.projects[_collection_repo].src_dir }}"
-      shell: "git commit -s -m 'Updated from network content collector'"


### PR DESCRIPTION
We really only need to commit on propose jobs, before we create the PR.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>