### PR TITLE
Switch to ansible-network/collection_migration

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -6,7 +6,8 @@
     post-run: tests/playbooks/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-community/collection_migration
+      - name: github.com/ansible-network/collection_migration
+        override-checkout: feature/network-collections
     timeout: 3600
     nodeset: fedora-latest-1vcpu
 
@@ -61,7 +62,8 @@
     run: tests/playbooks/run.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-community/collection_migration
+      - name: github.com/ansible-network/collection_migration
+        override-checkout: feature/network-collections
     timeout: 3600
     nodeset: fedora-latest-1vcpu
 
@@ -102,7 +104,10 @@
       ansible_collection_namespace: cisco
       ansible_collection_name: iosxr
 
-- project:
+- project-template:
+    name: network-collections-migration
+    description: |
+      A common set of migration jobs used by ansible network team
     check:
       jobs:
         - network-collections-migration-ansible-netcommon
@@ -110,6 +115,7 @@
         - network-collections-migration-cisco-ios
         - network-collections-migration-cisco-iosxr
     gate:
+      queue: network-collections-migration
       jobs:
         - network-collections-migration-ansible-netcommon
         - network-collections-migration-arista-eos
@@ -127,3 +133,7 @@
         - propose-network-collections-migration-arista-eos
         - propose-network-collections-migration-cisco-ios
         - propose-network-collections-migration-cisco-iosxr
+
+- project:
+    templates:
+      - network-collections-migration

--- a/README.rst
+++ b/README.rst
@@ -50,13 +50,16 @@ periodic pipelines to create new PRs if needed against:
 
 While still editing .zuul.yaml add the jobs to the pipelines:
 
-    - project:
+    - project-template:
+        name: network-collections-migration
+        description: |
+          A common set of migration jobs used by ansible network team
         check:
           jobs:
             - network-collections-migration-example-fake
         gate:
+          queue: network-collections-migration
           jobs:
-
             - network-collections-migration-example-fake
         periodic:
           jobs:

--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -40,32 +40,32 @@
 
     - name: Install python dependencies
       args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-community/collection_migration'].src_dir }}"
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}"
       shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/.tox/venv/bin/pip install -r requirements.txt"
 
     - name: Create .cache/releases directory
       args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-community/collection_migration'].src_dir }}"
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}"
       shell: mkdir -p .cache/releases
 
     - name: Symlink ansible/ansible to keep migrate.py happy
       args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-community/collection_migration'].src_dir }}"
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}"
       shell: "ln -s {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }} .cache/releases/devel.git"
 
     - name: Run migration
       args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-community/collection_migration'].src_dir }}"
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}"
       shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/.tox/venv/bin/python migrate.py -s {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/scenarios/{{ ansible_collection_namespace }}/{{ ansible_collection_name }}"
 
     - name: Delete unused content
       args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-community/collection_migration'].src_dir }}/.cache/collections/ansible_collections/{{ ansible_collection_namespace }}/{{ ansible_collection_name }}"
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}/.cache/collections/ansible_collections/{{ ansible_collection_namespace }}/{{ ansible_collection_name }}"
       shell: rm -rf galaxy.yml .git .github .gitignore README.md
 
     - name: Move content into collection git repo
       args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-community/collection_migration'].src_dir }}/.cache/collections/ansible_collections/{{ ansible_collection_namespace }}/{{ ansible_collection_name }}"
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}/.cache/collections/ansible_collections/{{ ansible_collection_namespace }}/{{ ansible_collection_name }}"
       shell: "mv * {{ ansible_user_dir }}/{{ zuul.projects[_collection_repo].src_dir }}"
 
     - name: Create target-prefixes.network for ansible-test


### PR DESCRIPTION
This allows us to merge fixes into our feature/network-collections
branch before pushing them up to ansible-community. We plan to sync from
upstream to keep as close a possible.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>