### PR TITLE
Add ansible-network/network_collections_migration as require-project

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -8,6 +8,7 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible-network/collection_migration
         override-checkout: feature/network-collections
+      - name: github.com/ansible-network/network_collections_migration
     timeout: 3600
     nodeset: fedora-latest-1vcpu
 
@@ -64,6 +65,7 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible-network/collection_migration
         override-checkout: feature/network-collections
+      - name: github.com/ansible-network/network_collections_migration
     timeout: 3600
     nodeset: fedora-latest-1vcpu
 


### PR DESCRIPTION
This allows other projects to run our jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>