### PR TITLE
Add soft dependency propose-network-collections-migration-ansible-netcommon

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -28,6 +28,9 @@
 
 - job:
     name: propose-network-collections-migration-arista-eos
+    dependencies:
+      - name: propose-network-collections-migration-ansible-netcommon
+        soft: true
     parent: propose-network-collections-migration-base
     required-projects:
       - name: github.com/ansible-network/ansible_collections.arista.eos
@@ -38,6 +41,9 @@
 
 - job:
     name: propose-network-collections-migration-cisco-ios
+    dependencies:
+      - name: propose-network-collections-migration-ansible-netcommon
+        soft: true
     parent: propose-network-collections-migration-base
     required-projects:
       - name: github.com/ansible-network/ansible_collections.cisco.ios
@@ -48,6 +54,9 @@
 
 - job:
     name: propose-network-collections-migration-cisco-iosxr
+    dependencies:
+      - name: propose-network-collections-migration-ansible-netcommon
+        soft: true
     parent: propose-network-collections-migration-base
     required-projects:
       - name: github.com/ansible-network/ansible_collections.cisco.iosxr

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,9 @@ First edit the .zuul.yaml file in this folder, adding the following 2 jobs:
 
     - job:
         name: propose-network-collections-migration-example-fake
+        dependencies:
+          - name: propose-network-collections-migration-ansible-netcommon
+            soft: true
         parent: propose-network-collections-migration-base
         required-projects:
           - name: github.com/ansible-network/ansible_collections.example.fake


### PR DESCRIPTION
This is mostly to ensure we first create PRs against this repo, then all
other network collections.  Helpful when doing cross project testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>