### PR TITLE
Add become/enable.py into ansible.netcommon collection

### DIFF
--- a/scenarios/ansible/netcommon/ansible.yml
+++ b/scenarios/ansible/netcommon/ansible.yml
@@ -15,6 +15,8 @@ netcommon:
   - net_put.py
   - netconf.py
   - network.py
+  become:
+  - enable.py
   connection:
   - httpapi.py
   - napalm.py


### PR DESCRIPTION
This is important for network_cli things.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>