### PR TITLE
Remove periodic jobs from project-template

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -132,12 +132,6 @@
         - network-collections-migration-arista-eos
         - network-collections-migration-cisco-ios
         - network-collections-migration-cisco-iosxr
-    periodic:
-      jobs:
-        - propose-network-collections-migration-ansible-netcommon
-        - propose-network-collections-migration-arista-eos
-        - propose-network-collections-migration-cisco-ios
-        - propose-network-collections-migration-cisco-iosxr
     post:
       jobs:
         - propose-network-collections-migration-ansible-netcommon
@@ -148,3 +142,9 @@
 - project:
     templates:
       - network-collections-migration
+    periodic:
+      jobs:
+        - propose-network-collections-migration-ansible-netcommon
+        - propose-network-collections-migration-arista-eos
+        - propose-network-collections-migration-cisco-ios
+        - propose-network-collections-migration-cisco-iosxr

--- a/README.rst
+++ b/README.rst
@@ -64,10 +64,14 @@ While still editing .zuul.yaml add the jobs to the pipelines:
           queue: network-collections-migration
           jobs:
             - network-collections-migration-example-fake
-        periodic:
+        post:
           jobs:
             - propose-network-collections-migration-example-fake
-        post:
+
+    - project:
+        templates:
+          - network-collections-migration
+        periodic:
           jobs:
             - propose-network-collections-migration-example-fake
 

--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -91,3 +91,8 @@
         tox_envlist: black
         tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects[_collection_repo].src_dir }}"
+
+    - name: Show git diff
+      args:
+        chdir: "{{ zuul.projects[_collection_repo].src_dir }}"
+      shell: git --no-pager diff


### PR DESCRIPTION
This avoids running migration jobs twice.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>