### PR TITLE
Remove dependency on ansible.netcommon for proposal jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -33,9 +33,6 @@
 
 - job:
     name: propose-network-collections-migration-arista-eos
-    dependencies:
-      - name: propose-network-collections-migration-ansible-netcommon
-        soft: true
     parent: propose-network-collections-migration-base
     required-projects:
       - name: github.com/ansible-network/ansible_collections.arista.eos
@@ -46,9 +43,6 @@
 
 - job:
     name: propose-network-collections-migration-cisco-ios
-    dependencies:
-      - name: propose-network-collections-migration-ansible-netcommon
-        soft: true
     parent: propose-network-collections-migration-base
     required-projects:
       - name: github.com/ansible-network/ansible_collections.cisco.ios
@@ -59,9 +53,6 @@
 
 - job:
     name: propose-network-collections-migration-cisco-iosxr
-    dependencies:
-      - name: propose-network-collections-migration-ansible-netcommon
-        soft: true
     parent: propose-network-collections-migration-base
     required-projects:
       - name: github.com/ansible-network/ansible_collections.cisco.iosxr

--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,6 @@ First edit the .zuul.yaml file in this folder, adding the following 2 jobs:
 
     - job:
         name: propose-network-collections-migration-example-fake
-        dependencies:
-          - name: propose-network-collections-migration-ansible-netcommon
-            soft: true
         parent: propose-network-collections-migration-base
         required-projects:
           - name: github.com/ansible-network/ansible_collections.example.fake


### PR DESCRIPTION
This didn't work as expected. Remove for now until I can debug a better
way to do this.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>