### PR TITLE
Rewrite cisco.netcommon.network_cli

### DIFF
--- a/tools/cleanup_tests.sh
+++ b/tools/cleanup_tests.sh
@@ -5,3 +5,6 @@ set -ex
 grep -RiIl 'httpapi' | xargs perl -i -pe 's/((ansible_)?connection)(.*)((?<!_|\.)httpapi)/\1\3ansible.netcommon.\4/g' | true
 # network_cli -> ansible.netcommon.network_cli
 grep -RiIl 'network_cli' | xargs perl -i -pe 's/((ansible_)?connection)(.*)((?<!_|\.)network_cli)/\1\3ansible.netcommon.\4/g' | true
+# cisco.netcommon.network_cli -> ansible.netcommon.network_cli
+# TODO(pabelager): This is a bug in migrate.py, we should fix it
+grep -RiIl 'cisco.netcommon.network_cli' | xargs perl -i -pe 's/cisco.netcommon.network_cli/ansible.netcommon.network_cli/g' | true


### PR DESCRIPTION
This is a bug in our migration script, for now deal with it here.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>