### PR TITLE
Rename _foo.py to foo.py for migrate.py

### DIFF
--- a/tests/playbooks/build-ansible-minimal/run-post.yaml
+++ b/tests/playbooks/build-ansible-minimal/run-post.yaml
@@ -3,7 +3,7 @@
     - name: Run migration
       args:
         chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}"
-      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/.tox/venv/bin/python migrate.py -d -n -m -b -R -s {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}/scenarios/minimal"
+      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/.tox/venv/bin/python migrate.py -m -b -R -s {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}/scenarios/minimal"
 
     - name: Build python sdist
       args:

--- a/tests/playbooks/run-post.yaml
+++ b/tests/playbooks/run-post.yaml
@@ -3,7 +3,7 @@
     - name: Run migration
       args:
         chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}"
-      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/.tox/venv/bin/python migrate.py -d -n -s {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/scenarios/{{ ansible_collection_namespace }}/{{ ansible_collection_name }}"
+      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/.tox/venv/bin/python migrate.py -s {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/scenarios/{{ ansible_collection_namespace }}/{{ ansible_collection_name }}"
 
     - name: Delete unused content
       args:

--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -22,3 +22,13 @@
       args:
         chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}"
       shell: "ln -s {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }} .cache/releases/devel.git"
+
+    - name: Rename deprecated modules (network)
+      args:
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/lib/ansible/modules/network"
+      shell: "python {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/tools/rename_deprecated.py"
+
+    - name: git commit to keep migrate.py happy
+      args:
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
+      shell: "git add --all && git commit -a -m 'rename deprecated'"

--- a/tools/rename_deprecated.py
+++ b/tools/rename_deprecated.py
@@ -1,0 +1,11 @@
+import os
+
+
+for dirpath, dirname, filenames in os.walk('.'):
+    for f in filenames:
+        if '__init__.py' in f or not f.startswith('_'):
+            continue
+        src = os.path.join(dirpath, f)
+        dest = os.path.join(dirpath, f[1:])
+        print('Renaming %s -> %s', src, dest)
+        os.rename(src, dest)


### PR DESCRIPTION
Rather then hack up migrate.py, for now just rename all network modules
from _foo.py to foo.py. We do this until the migration tools supports it
properly.

Depends-On: https://github.com/ansible-network/collection_migration/pull/10
Signed-off-by: Paul Belanger <pabelanger@redhat.com>