### PR TITLE
Remove job.files for build-ansible-minimal

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -167,9 +167,6 @@
       - name: github.com/ansible-network/network_collections_migration
     timeout: 5400
     nodeset: fedora-latest-1vcpu
-    files:
-      - tests/playbooks/.*
-      - tools/.*
 
 - project-template:
     name: network-collections-migration


### PR DESCRIPTION
This is breaking our collections jobs in other repos, as filematcher is
failing to match.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>