### PR TITLE
Re-write iosxr tasks for ansible.netcommon

### DIFF
--- a/scenarios/ansible/netcommon/cisco.yml
+++ b/scenarios/ansible/netcommon/cisco.yml
@@ -1,0 +1,1 @@
+../../cisco/iosxr/cisco.yml


### PR DESCRIPTION
We need to load cisco.iosxr migration data, so we can properly rewrite
tests.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>