### PR TITLE
Also include junipernetworks for ansible.netcommon collection

### DIFF
--- a/scenarios/ansible/netcommon/junipernetworks.yml
+++ b/scenarios/ansible/netcommon/junipernetworks.yml
@@ -1,0 +1,1 @@
+../../junipernetworks/junos/junipernetworks.yml


### PR DESCRIPTION
This is because we run tests against junos too.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>