### PR TITLE
Create build-ansible-base job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -199,13 +199,17 @@
     timeout: 5400
     nodeset: fedora-latest-1vcpu
 
+- job:
+    name: build-ansible-base
+    parent: build-ansible-minimal
+
 - project-template:
     name: network-collections-migration
     description: |
       A common set of migration jobs used by ansible network team
     check:
       jobs:
-        - build-ansible-minimal
+        - build-ansible-base
         - network-collections-migration-ansible-netcommon
         - network-collections-migration-arista-eos
         - network-collections-migration-cisco-ios
@@ -215,7 +219,7 @@
     gate:
       queue: network-collections-migration
       jobs:
-        - build-ansible-minimal
+        - build-ansible-base
         - network-collections-migration-ansible-netcommon
         - network-collections-migration-arista-eos
         - network-collections-migration-cisco-ios


### PR DESCRIPTION
This is the first step to remove build-ansible-minimal job.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>