### PR TITLE
Add ansible.netcommon dependency to arista.eos

### DIFF
--- a/scenarios/ansible/netcommon/arista.yml
+++ b/scenarios/ansible/netcommon/arista.yml
@@ -1,0 +1,1 @@
+../../arista/eos/arista.yml


### PR DESCRIPTION
This is to allow for rewrites of imports.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>