### PR TITLE
Switch to venv for migrate.py scripts

### DIFF
--- a/tests/playbooks/build-ansible-minimal/run-post.yaml
+++ b/tests/playbooks/build-ansible-minimal/run-post.yaml
@@ -3,14 +3,14 @@
     - name: Run migration
       args:
         chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}"
-      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/.tox/venv/bin/python migrate.py -m -b -R -s {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}/scenarios/minimal"
+      shell: "~/venv/bin/python migrate.py -m -b -R -s {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}/scenarios/minimal"
 
     - name: Build python sdist
       args:
         chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
       environment:
         _ANSIBLE_SDIST_FROM_MAKEFILE: 1
-      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/.tox/venv/bin/python setup.py sdist"
+      shell: ~/venv/bin/python setup.py sdist
 
     - name: Create artifacts directory
       shell: mkdir ~/artifacts

--- a/tests/playbooks/run-post.yaml
+++ b/tests/playbooks/run-post.yaml
@@ -3,7 +3,7 @@
     - name: Run migration
       args:
         chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}"
-      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/.tox/venv/bin/python migrate.py -s {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/scenarios/{{ ansible_collection_namespace }}/{{ ansible_collection_name }}"
+      shell: "~/venv/bin/python migrate.py -s {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/scenarios/{{ ansible_collection_namespace }}/{{ ansible_collection_name }}"
 
     - name: Delete unused content
       args:

--- a/tests/playbooks/run.yaml
+++ b/tests/playbooks/run.yaml
@@ -1,5 +1,12 @@
 - hosts: all
   tasks:
+    - name: Create virtualenv for migration.py
+      shell: virtualenv ~/venv
+
+    - name: Install selinux into virtualenv
+      shell: ~/venv/bin/pip install selinux
+      when: ansible_os_family == "RedHat"
+
     - name: Bootstrap tox environment
       include_role:
         name: tox
@@ -11,7 +18,7 @@
     - name: Install python dependencies
       args:
         chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/collection_migration'].src_dir }}"
-      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/network_collections_migration'].src_dir }}/.tox/venv/bin/pip install -r requirements.txt"
+      shell: ~/venv/bin/pip install -r requirements.txt
 
     - name: Create .cache/releases directory
       args:


### PR DESCRIPTION
This removed tox dependency, which doesn't exist in upstream.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>