### PR TITLE
Add compat/ipaddress.py to ansible.netcommon

### DIFF
--- a/scenarios/ansible/netcommon/ansible.yml
+++ b/scenarios/ansible/netcommon/ansible.yml
@@ -11,6 +11,7 @@ netcommon:
   - network/routing/*
   - network/system/*
   module_utils:
+  - compat/ipaddress.py
   - network/common/*
   - network/common/*/*
   - network/netconf/*


### PR DESCRIPTION
We have network modules that depend on this.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>