### PR TITLE
Switch to github.com/ansible-collection-migration/ansible-base

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -215,8 +215,7 @@
     run: tests/playbooks/build-ansible-minimal/run-post.yaml
     post-run: tests/playbooks/build-ansible-minimal/post.yaml
     required-projects:
-      - name: github.com/ansible/ansible
-      - name: github.com/ansible-community/collection_migration
+      - name: github.com/ansible-collection-migration/ansible-base
       - name: github.com/ansible-network/network_collections_migration
     timeout: 5400
     nodeset: fedora-latest-1vcpu

--- a/tests/playbooks/build-ansible-minimal/pre.yaml
+++ b/tests/playbooks/build-ansible-minimal/pre.yaml
@@ -16,18 +16,3 @@
     - name: Install selinux into virtualenv
       shell: ~/venv/bin/pip install selinux
       when: ansible_os_family == "RedHat"
-
-    - name: Install python dependencies
-      args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-community/collection_migration'].src_dir }}"
-      shell: ~/venv/bin/pip install -r requirements.txt
-
-    - name: Create .cache/releases directory
-      args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-community/collection_migration'].src_dir }}"
-      shell: mkdir -p .cache/releases
-
-    - name: Symlink ansible/ansible to keep migrate.py happy
-      args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-community/collection_migration'].src_dir }}"
-      shell: "ln -s {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }} .cache/releases/devel.git"

--- a/tests/playbooks/build-ansible-minimal/run-post.yaml
+++ b/tests/playbooks/build-ansible-minimal/run-post.yaml
@@ -1,13 +1,8 @@
 - hosts: all
   tasks:
-    - name: Run migration
-      args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-community/collection_migration'].src_dir }}"
-      shell: "~/venv/bin/python migrate.py -m -R -s {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-community/collection_migration'].src_dir }}/scenarios/base --convert-symlinks --skip-publish"
-
     - name: Build python sdist
       args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-collection-migration/ansible-base'].src_dir }}"
       environment:
         _ANSIBLE_SDIST_FROM_MAKEFILE: 1
       shell: ~/venv/bin/python setup.py sdist
@@ -17,5 +12,5 @@
 
     - name: Move sdist into artifacts directory
       args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-collection-migration/ansible-base'].src_dir }}"
       shell: mv dist/*.tar.gz ~/artifacts


### PR DESCRIPTION
There is no need to run migrate.py any more, but keep the job for now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>