### PR TITLE
Remove periodic jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -370,16 +370,3 @@
 - project:
     templates:
       - network-collections-migration
-    periodic:
-      jobs:
-        - propose-network-collections-migration-ansible-netcommon
-        - propose-network-collections-migration-arista-eos
-        - propose-network-collections-migration-checkpoint-checkpoint
-        - propose-network-collections-migration-cisco-ios
-        - propose-network-collections-migration-cisco-iosxr
-        - propose-network-collections-migration-cisco-nxos
-        - propose-network-collections-migration-frr-frr
-        - propose-network-collections-migration-junipernetworks-junos
-        - propose-network-collections-migration-openvswitch-openvswitch
-        - propose-network-collections-migration-skydive-skydive
-        - propose-network-collections-migration-vyos-vyos


### PR DESCRIPTION
We no longer need to sync from ansible/ansible, it is frozen.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>